### PR TITLE
add http methods support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ type NotFoundError : Error & {
 }
 
 type Router : {
-    set: (pattern: String, handler: Function) => void
+    set: (pattern: String, handler: Function | Object) => void
 } & (
     req: HttpReqest,
     res: HttpResponse,
@@ -91,7 +91,7 @@ it will throw the `http-hash-router.expected-callback` exception.
 
 ```ocaml
 type RoutePattern : String
-type RouteHandler : (
+type RouteHandler : Object<method: String, RouteHandler> | (
     req: HttpRequest,
     res: HttpResponse,
     opts: Object & {
@@ -106,6 +106,11 @@ set : (RoutePattern, RouteHandler) => void
 
 You can call `.set()` on the router and it will internally
 store your handler against the pattern.
+
+`.set()` takes a route pattern and a route handler. A route
+    handler is either a function or an object. If you use
+    an object then we will create a route handler function
+    using the [`http-methods`][http-methods] module.
 
 The `.set()` functionality is implemented by
 [`http-hash`][http-hash] itself and you can find documentation
@@ -127,3 +132,4 @@ the values of the params and splat will be passed to the
 
   [http-hash]: https://github.com/Matt-Esch/http-hash
   [http-hash-set]: https://github.com/Matt-Esch/http-hash#hashsetpath-handler
+  [http-methods]: https://github.com/Raynos/http-methods

--- a/docs.jsig
+++ b/docs.jsig
@@ -1,7 +1,7 @@
 import { HttpRequest, HttpResponse } from "node.http"
 
 type RoutePattern : String
-type RouteHandler : (
+type RouteHandler : Object<method: String, RouteHandler> | (
     req: HttpRequest,
     res: HttpResponse,
     opts: Object & {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var HttpHash = require('http-hash');
 var url = require('url');
 var TypedError = require('error/typed');
 var extend = require('xtend');
+var httpMethods = require('http-methods/method');
 
 var ExpectedCallbackError = TypedError({
     type: 'http-hash-router.expected.callback',
@@ -24,9 +25,18 @@ module.exports = HttpHashRouter;
 function HttpHashRouter() {
     var hash = HttpHash();
 
-    handleRequest.set = hash.set.bind(hash);
+    handleRequest.hash = hash;
+    handleRequest.set = set;
 
     return handleRequest;
+
+    function set(name, handler) {
+        if (handler && typeof handler === 'object') {
+            handler = httpMethods(handler);
+        }
+
+        return hash.set(name, handler);
+    }
 
     function handleRequest(req, res, opts, cb) {
         if (typeof cb !== 'function') {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "error": "^5.0.0",
     "http-hash": "^1.0.2",
+    "http-methods": "^1.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -117,6 +117,55 @@ test('supports splats', function t(assert) {
     });
 });
 
+test('supports methods', function t(assert) {
+    var router = HttpHashRouter();
+    var server = http.createServer(defaultHandler(router));
+    server.listen(0);
+
+    router.set('/foo', {
+        GET: function onFoo(req, res) {
+            res.end('get');
+        },
+        POST: function onPost(req, res) {
+            res.end('post');
+        }
+    });
+
+    makeRequest(server, {
+        url: '/foo',
+        method: 'GET'
+    }, function onResp(err, resp) {
+        assert.ifError(err);
+
+        assert.equal(resp.statusCode, 200);
+        assert.equal(resp.body, 'get');
+
+        makeRequest(server, {
+            url: '/foo',
+            method: 'POST'
+        }, function onResp(err, resp) {
+            assert.ifError(err);
+
+            assert.equal(resp.statusCode, 200);
+            assert.equal(resp.body, 'post');
+
+            makeRequest(server, {
+                url: '/foo',
+                method: 'PUT'
+            }, function onResp(err, resp) {
+                assert.ifError(err);
+
+                assert.equal(resp.statusCode, 405);
+                assert.equal(resp.body,
+                    '405 Method Not Allowed /foo');
+
+                server.close();
+                assert.end();
+            });
+        });
+    });
+});
+
 function defaultHandler(hashRouter) {
     return function handler(req, res) {
         hashRouter(req, res, {}, function onError(err) {


### PR DESCRIPTION
This allows you to do:

``` js
router.set('/foo/:bar', {
  'GET': function () {},
  'POST': function () {}
})
```

The implementation is backed by `http-methods`.

reviewers: @Matt-Esch

cc @nrw
